### PR TITLE
Manually adding / removing call backs

### DIFF
--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -11,7 +11,7 @@ namespace HybridWebView
         ///  The path within the app's "Raw" asset resources that contain the web app's contents. For example, if the
         ///  files are located in "ProjectFolder/Resources/Raw/hybrid_root", then set this property to "hybrid_root".
         /// </summary>
-        public string HybridAssetRoot { get; set; }
+        public string HybridAssetRoot { get; set; } = string.Empty;
 
         /// <summary>
         /// The target object for JavaScript method invocations. When an "invoke" message is sent from JavaScript,

--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -113,8 +113,10 @@ namespace HybridWebView
 
 
         internal readonly Dictionary<string, (object,MethodInfo)> LocalRegisteredCallbacks = new();
-        public void AddLocalCallback(object callingClass, MethodInfo action)
+        public void AddLocalCallback(object callingClass, string methodName)
         {
+            var action = callingClass.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.InvokeMethod);
+
             if (LocalRegisteredCallbacks.ContainsKey(action.Name))
                 LocalRegisteredCallbacks.Remove(action.Name);
 

--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -92,12 +92,12 @@ namespace HybridWebView
                 
             if(invokeMethod is null)
             {
-                (object containingClass, MethodInfo method)? test = LocalRegisteredCallbacks.Where(x => x.Key.Equals(invokeData.MethodName)).Select(x => x.Value).FirstOrDefault();
+                (object containingClass, MethodInfo method)? localMethod = LocalRegisteredCallbacks.Where(x => x.Key.Equals(invokeData.MethodName)).Select(x => x.Value).FirstOrDefault();
 
-                if(test is not null)
+                if(localMethod is not null)
                 {
-                    invokeMethod = test.Value.method;
-                    containingClass = test.Value.containingClass;
+                    invokeMethod = localMethod.Value.method;
+                    containingClass = localMethod.Value.containingClass;
                 }
             }
 

--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -115,13 +115,19 @@ namespace HybridWebView
         internal readonly Dictionary<string, (object,MethodInfo)> LocalRegisteredCallbacks = new();
         public void AddLocalCallback(object callingClass, string methodName)
         {
-            var action = callingClass.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.InvokeMethod);
+            MethodInfo action = callingClass.GetType().GetMethod(methodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.InvokeMethod);
 
             if (LocalRegisteredCallbacks.ContainsKey(action.Name))
                 LocalRegisteredCallbacks.Remove(action.Name);
 
             LocalRegisteredCallbacks.Add(action.Name, (callingClass, action));
         }
+        public void RemoveLocalCallback(string methodName)
+        {
+            if (LocalRegisteredCallbacks.ContainsKey(methodName))
+                LocalRegisteredCallbacks.Remove(methodName);
+        }
+
         private sealed class JSInvokeMethodData
         {
             public string MethodName { get; set; }

--- a/MauiCSharpInteropWebView/MainPage.xaml.cs
+++ b/MauiCSharpInteropWebView/MainPage.xaml.cs
@@ -16,8 +16,6 @@ public partial class MainPage : ContentPage
         myHybridWebView.JSInvokeTarget = new MyJSInvokeTarget(this);
 
         myHybridWebView.AddLocalCallback(this, nameof(AddLocalCallBackTest));
-
-        myHybridWebView.AddLocalCallback(this, GetType().GetMethod(nameof(AddLocalCallBackTest), BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.InvokeMethod));
     }
 
     public string CurrentPageName => $"Current hybrid page: {_currentPage}";

--- a/MauiCSharpInteropWebView/MainPage.xaml.cs
+++ b/MauiCSharpInteropWebView/MainPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿namespace MauiCSharpInteropWebView;
+﻿using System.Reflection;
+
+namespace MauiCSharpInteropWebView;
 
 public partial class MainPage : ContentPage
 {
@@ -12,6 +14,10 @@ public partial class MainPage : ContentPage
         BindingContext = this;
 
         myHybridWebView.JSInvokeTarget = new MyJSInvokeTarget(this);
+
+        myHybridWebView.AddLocalCallback(this, nameof(AddLocalCallBackTest));
+
+        myHybridWebView.AddLocalCallback(this, GetType().GetMethod(nameof(AddLocalCallBackTest), BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.InvokeMethod));
     }
 
     public string CurrentPageName => $"Current hybrid page: {_currentPage}";
@@ -24,6 +30,11 @@ public partial class MainPage : ContentPage
     private async void OnSendRawMessageToJS(object sender, EventArgs e)
     {
         _ = await myHybridWebView.EvaluateJavaScriptAsync($"SendToJs('Sent from .NET, the time is: {DateTimeOffset.Now}!')");
+    }
+
+    private async void AddLocalCallBackTest(string message, int value)
+    {
+        WriteToLog($"I'm a .NET method called from JavaScript with message='{message}' and value={value}, using a local registration");
     }
 
     private async void OnInvokeJSMethod(object sender, EventArgs e)

--- a/MauiCSharpInteropWebView/MainPage.xaml.cs
+++ b/MauiCSharpInteropWebView/MainPage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-
-namespace MauiCSharpInteropWebView;
+﻿namespace MauiCSharpInteropWebView;
 
 public partial class MainPage : ContentPage
 {
@@ -15,6 +13,7 @@ public partial class MainPage : ContentPage
 
         myHybridWebView.JSInvokeTarget = new MyJSInvokeTarget(this);
 
+        // Register in the constructor or anywhere else
         myHybridWebView.AddLocalCallback(this, nameof(AddLocalCallBackTest));
     }
 

--- a/MauiCSharpInteropWebView/MainPage.xaml.cs
+++ b/MauiCSharpInteropWebView/MainPage.xaml.cs
@@ -84,5 +84,6 @@ public partial class MainPage : ContentPage
         MainPage = 0,
         RawMessages = 1,
         MethodInvoke = 2,
+        ManualRegister = 3,
     }
 }

--- a/MauiCSharpInteropWebView/MauiCSharpInteropWebView.csproj
+++ b/MauiCSharpInteropWebView/MauiCSharpInteropWebView.csproj
@@ -49,11 +49,21 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <None Remove="Resources\Raw\hybrid_root\localMethodinvoke.html" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\HybridWebView\HybridWebView.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <MauiAsset Update="Resources\Raw\hybrid_root\localmethodinvoke.html">
+	    <LogicalName>%(RecursiveDir)%(Filename)%(Extension)</LogicalName>
+	  </MauiAsset>
 	</ItemGroup>
 
 </Project>

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/hybrid_app.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/hybrid_app.html
@@ -10,7 +10,7 @@
 <body>
     <h1>HybridWebView demo: Main page</h1>
     <div class="navBar">
-        Main page | <a href="/rawmessages.html">Raw messages</a> | <a href="/methodinvoke.html">Method invoke</a>
+        Main page | <a href="/rawmessages.html">Raw messages</a> | <a href="/methodinvoke.html">Method invoke</a> | <a href="/localmethodinvoke.html">Local method invoke</a>
     </div>
     <div>
         Welcome to the HybridWebView demo for .NET MAUI!

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/localMethodinvoke.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/localMethodinvoke.html
@@ -1,0 +1,51 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+    <script>
+        function JsAddNumbers(a, b) {
+            var sum = a + b;
+            Log('Called from .NET with values (' + a + ', ' + b + '), and returning the sum: ' + sum);
+            return sum;
+        }
+
+        function CallDotNetMethod() {
+            Log('Calling a method in .NET with some parameters');
+
+			HybridWebView.SendInvokeMessageToDotNet("AddLocalCallBackTest", ["msg from js", 987]);
+        }
+    </script>
+    <script src="js/HybridWebView.js"></script>
+    <script src="js/extra_code.js"></script>
+    <link href="styles/my-styles.css" rel="stylesheet" />
+</head>
+<body>
+    <h1>HybridWebView demo: Method invoke</h1>
+    <div class="navBar">
+        <a href="/">Main page</a> | <a href="/rawmessages.html">Raw messages</a> | Method invoke
+    </div>
+    <div>
+        Methods can be invoked in both directions:
+
+        <ul>
+            <li>JavaScript can invoke .NET methods by calling <code>HybridWebView.SendInvokeMessageToDotNet("DotNetMethodName", ["param1", 123]);</code>.</li>
+            <li>.NET can invoke JavaScript methods by calling <code>var sum = await webView.InvokeJsMethodAsync<int>("JsAddNumbers", 123, 456);</code>.</li>
+        </ul>
+    </div>
+    <div>
+        <button type="button" onclick="CallDotNetMethod()">Call .NET method with some parameters</button>
+    </div>
+    <h2>
+        JS message log:
+    </h2>
+    <div>
+        <textarea id="messageLog" style="width: 90%; height: 10em;"></textarea>
+    </div>
+    <script>
+        // Notify .NET code which page we're on
+        HybridWebView.SendRawMessageToDotNet("page:2");
+    </script>
+</body>
+</html>

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/localMethodinvoke.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/localMethodinvoke.html
@@ -14,17 +14,17 @@
         function CallDotNetMethod() {
             Log('Calling a method in .NET with some parameters');
 
-			HybridWebView.SendInvokeMessageToDotNet("AddLocalCallBackTest", ["msg from js", 987]);
+            HybridWebView.SendInvokeMessageToDotNet("AddLocalCallBackTest", ["msg from js", 987]);
         }
     </script>
-    <script src="js/HybridWebView.js"></script>
+    <script src="_hwv/HybridWebView.js"></script>
     <script src="js/extra_code.js"></script>
     <link href="styles/my-styles.css" rel="stylesheet" />
 </head>
 <body>
     <h1>HybridWebView demo: Method invoke</h1>
     <div class="navBar">
-        <a href="/">Main page</a> | <a href="/rawmessages.html">Raw messages</a> | Method invoke
+        <a href="/">Main page</a> | <a href="/rawmessages.html">Raw messages</a> | <a href="/methodinvoke.html">Method invoke</a> | Local method invoke
     </div>
     <div>
         Methods can be invoked in both directions:
@@ -45,7 +45,7 @@
     </div>
     <script>
         // Notify .NET code which page we're on
-        HybridWebView.SendRawMessageToDotNet("page:2");
+        HybridWebView.SendRawMessageToDotNet("page:3");
     </script>
 </body>
 </html>

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/methodinvoke.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/methodinvoke.html
@@ -24,7 +24,7 @@
 <body>
     <h1>HybridWebView demo: Method invoke</h1>
     <div class="navBar">
-        <a href="/">Main page</a> | <a href="/rawmessages.html">Raw messages</a> | Method invoke
+        <a href="/">Main page</a> | <a href="/rawmessages.html">Raw messages</a> | Method invoke | <a href="/localmethodinvoke.html">Local method invoke</a>
     </div>
     <div>
         Methods can be invoked in both directions:

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/rawmessages.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/rawmessages.html
@@ -22,7 +22,7 @@
 <body>
     <h1>HybridWebView demo: Raw messages</h1>
     <div class="navBar">
-        <a href="/">Main page</a> | Raw messages | <a href="/methodinvoke.html">Method invoke</a>
+        <a href="/">Main page</a> | Raw messages | <a href="/methodinvoke.html">Method invoke</a> | <a href="/localmethodinvoke.html">Local method invoke</a>
     </div>
     <div>
         Raw messages are sent as a raw string from JavaScript to .NET with no further processing.


### PR DESCRIPTION
> Sorry same draft PR as before, when i tried syncing my main branch it auto deleted my commits #1 

Hi, great work on this control.

Thought I'd just do a draft PR to show an implementation I prefer. I'm not a big fan JSInvokeTarget, think it could add some complexity to some simpler use cases.

So I propose adding 2 methods to Add/ Remove JS callback methods.

That way to don't need a completely separate class that contain all the call back methods, you could simply do this - 

```csharp
// Register in the constructor or anywhere else
myHybridWebView.AddLocalCallback(this, nameof(AddLocalCallBackTest));

private async void AddLocalCallBackTest(string message, int value)
{
    WriteToLog($"I'm a .NET method called from JavaScript with message='{message}' and value={value}, using a local registration");
}
```

