### PR TITLE
[feature] update project to use .NET 8

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -31,11 +31,11 @@ jobs:
           echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_14.1.app" >> $GITHUB_ENV
         if: ${{ matrix.os == 'macos-latest' }}
 
-      - name: Install .NET 7 SDK
-        uses: actions/setup-dotnet@v3
+      - name: Install .NET 8 SDK
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.100
+            8.0.100
 
       - name: Install MAUI Workload
         run: dotnet workload install maui --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/7.0.1xx.json --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install .NET 7 SDK
-        uses: actions/setup-dotnet@v3
+      - name: Install .NET 8 SDK
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.202
+            8.0.100
 
       - name: Install MAUI Workload
         run: dotnet workload install maui --ignore-failed-sources

--- a/HybridWebView/HybridWebView.csproj
+++ b/HybridWebView/HybridWebView.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -58,5 +58,10 @@
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
+	</ItemGroup>
 
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Eilon Lipton
+Copyright (c) 2023 Eilon Lipton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MauiCSharpInteropWebView/MauiCSharpInteropWebView.csproj
+++ b/MauiCSharpInteropWebView/MauiCSharpInteropWebView.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiCSharpInteropWebView</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -49,7 +49,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MauiReactJSHybridApp/MauiReactJSHybridApp.csproj
+++ b/MauiReactJSHybridApp/MauiReactJSHybridApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiReactJSHybridApp</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -49,7 +49,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Or please log an issue in this repo for any other topics.
 
 ## Getting Started
 
-To get started, you'll need a .NET MAUI 7 project, then add the HybridWebView control, and add some web content to it.
+To get started, you'll need a .NET MAUI 8 project, then add the HybridWebView control, and add some web content to it.
 
 Note: If you'd like to check out an already completed sample, go to https://github.com/Eilon/SampleMauiHybridWebViewProject
 
 1. Ensure you have Visual Studio 2022 with the .NET MAUI workload installed
-1. Create a **.NET MAUI App** project that targets .NET 7 (or use an existing one)
+1. Create a **.NET MAUI App** project that targets .NET 8 (or use an existing one)
 1. Add a reference to the `EJL.MauiHybridWebView` package:
     1. Right-click on the **Dependencies** node in Solution Explorer and select **Manage NuGet Packages**
     1. Select the **Browse** tab
@@ -108,7 +108,7 @@ Note: If you'd like to check out an already completed sample, go to https://gith
 
 ## How to run the source code in this repo
 
-To run this app you need to have [Visual Studio for Windows or Mac, including the .NET MAUI workload](https://learn.microsoft.com/dotnet/maui/get-started/installation?view=net-maui-7.0). Then clone this repo, open the solution, and run one of the sample projects.
+To run this app you need to have [Visual Studio for Windows or Mac, including the .NET MAUI workload](https://learn.microsoft.com/dotnet/maui/get-started/installation?view=net-maui-8.0). Then clone this repo, open the solution, and run one of the sample projects.
 
 ## MauiReactJSHybridApp React JS app
 


### PR DESCRIPTION
- .NET version updated to v8
- .NET MAUI 8 migration done (implicit package references)
- GitHub workflows updated
- minor changes to copy/links/year across text assets

Changes as per guide:
https://github.com/dotnet/maui/wiki/Upgrading-.NET-MAUI-from-.NET-7-to-.NET-8

Build with Rider and run on Mac OS (Catalyst)

Thanks!