### PR TITLE
Fix NullRef when JS method has no return value

### DIFF
--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -88,6 +88,10 @@ namespace HybridWebView
         {
             var stringResult = await InvokeJsMethodAsync(methodName, paramValues);
 
+            if (stringResult is null)
+            {
+                return default;
+            }
             return JsonSerializer.Deserialize<TReturnType>(stringResult);
         }
 


### PR DESCRIPTION
The InvokeJsMethodAsync() method now returns null if there was no return value.

Fixes #27