### PR TITLE
Update webview host address to 0.0.0.1

### DIFF
--- a/HybridWebView/Platforms/Android/HybridWebView.Android.cs
+++ b/HybridWebView/Platforms/Android/HybridWebView.Android.cs
@@ -6,10 +6,10 @@ namespace HybridWebView
 {
     partial class HybridWebView
     {
-        private static readonly string AppHostAddress = "0.0.0.0";
+        private static readonly string AppHostAddress = "0.0.0.1";
 
         /// <summary>
-        /// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>
+        /// Gets the application's base URI. Defaults to <c>https://0.0.0.1/</c>
         /// </summary>
         private static readonly string AppOrigin = $"https://{AppHostAddress}/";
 

--- a/HybridWebView/Platforms/MacCatalyst/HybridWebView.MacCatalyst.cs
+++ b/HybridWebView/Platforms/MacCatalyst/HybridWebView.MacCatalyst.cs
@@ -5,7 +5,7 @@ namespace HybridWebView
 {
     partial class HybridWebView
     {
-        internal const string AppHostAddress = "0.0.0.0";
+        internal const string AppHostAddress = "0.0.0.1";
 
         internal const string AppOrigin = "app://" + AppHostAddress + "/";
         internal static readonly Uri AppOriginUri = new(AppOrigin);

--- a/HybridWebView/Platforms/Windows/HybridWebView.Windows.cs
+++ b/HybridWebView/Platforms/Windows/HybridWebView.Windows.cs
@@ -10,10 +10,10 @@ namespace HybridWebView
         // Using an IP address means that WebView2 doesn't wait for any DNS resolution,
         // making it substantially faster. Note that this isn't real HTTP traffic, since
         // we intercept all the requests within this origin.
-        private static readonly string AppHostAddress = "0.0.0.0";
+        private static readonly string AppHostAddress = "0.0.0.1";
 
         /// <summary>
-        /// Gets the application's base URI. Defaults to <c>https://0.0.0.0/</c>
+        /// Gets the application's base URI. Defaults to <c>https://0.0.0.1/</c>
         /// </summary>
         private static readonly string AppOrigin = $"https://{AppHostAddress}/";
 

--- a/HybridWebView/Platforms/iOS/HybridWebView.iOS.cs
+++ b/HybridWebView/Platforms/iOS/HybridWebView.iOS.cs
@@ -5,7 +5,7 @@ namespace HybridWebView
 {
     partial class HybridWebView
     {
-        internal const string AppHostAddress = "0.0.0.0";
+        internal const string AppHostAddress = "0.0.0.1";
 
         internal const string AppOrigin = "app://" + AppHostAddress + "/";
         internal static readonly Uri AppOriginUri = new(AppOrigin);

--- a/MauiCSharpInteropWebView/Platforms/Windows/Package.appxmanifest
+++ b/MauiCSharpInteropWebView/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.1" />
 
   <mp:PhoneIdentity PhoneProductId="5B5DF893-8256-45F3-B7A6-10C1FFA69401" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/proxy.html
+++ b/MauiCSharpInteropWebView/Resources/Raw/hybrid_root/proxy.html
@@ -65,7 +65,7 @@
         This is useful in scenarios where the request is being made from HTML elements, like an <code>img</code> tag, or a external library that only takes in string URLs.
         Proxy request URLs can be created with the format <code>/proxy?</code> and appending a custom query string. Some JavaScript libraries may require the full URL to be passed in. 
         This can be done by calling <code>`${window.location.origin}/proxy?`</code> and appending the custom query string.
-        Proxy URLs will look something like this: <code>https://0.0.0.0/proxy?myParameter=myValue</code> or <code>app://0.0.0.0/proxy?myParameter=myValue</code> depending on the platform.
+        Proxy URLs will look something like this: <code>https://0.0.0.1/proxy?myParameter=myValue</code> or <code>app://0.0.0.1/proxy?myParameter=myValue</code> depending on the platform.
     </div>
     <div>
         <b>Create proxy URLs and pass into native HTML elements</b>

--- a/MauiReactJSHybridApp/Platforms/Windows/Package.appxmanifest
+++ b/MauiReactJSHybridApp/Platforms/Windows/Package.appxmanifest
@@ -6,7 +6,7 @@
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
 
-  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.0" />
+  <Identity Name="maui-package-name-placeholder" Publisher="CN=User Name" Version="0.0.0.1" />
 
   <mp:PhoneIdentity PhoneProductId="C144569D-A0AF-41CF-BBF9-CE7F1654CD23" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
This fixes iOS/MacCat 18 and also helps future-proof in case other platforms start blocking the old address (0.0.0.0).

Fixes #78