### PR TITLE
fix System.NullReferenceException when disconnecting Handler

### DIFF
--- a/HybridWebView/HybridWebView.cs
+++ b/HybridWebView/HybridWebView.cs
@@ -62,6 +62,12 @@ namespace HybridWebView
 
             await InitializeHybridWebView();
 
+            // HybridWebViewInitialized assumes Handler != null
+            if (Handler == null)
+            {
+                return;
+            }
+
             HybridWebViewInitialized?.Invoke(this, new HybridWebViewInitializedEventArgs()
             {
 #if ANDROID || IOS || MACCATALYST || WINDOWS


### PR DESCRIPTION
Besides, disconnecting the Handler is a workaround for memory leaks:
https://github.com/dotnet/maui/issues/20283#issuecomment-2218729505